### PR TITLE
Download Module

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -69,7 +69,7 @@ $config['migration_auto_latest'] = FALSE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 38;
+$config['migration_version'] = 39;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -90,6 +90,15 @@ $route[$lang.'/donate'] = 'donate/index';
 $route[$lang.'/donate/check/(:any)'] = 'donate/check/$2';
 $route[$lang.'/donate/canceled'] = 'donate/canceled';
 
+/*Download*/
+$route[$lang.'/download'] = 'download/index';
+$route[$lang.'/admin/download'] = 'admin/managedownload';
+$route[$lang.'/admin/download/create'] = 'admin/createdownload';
+$route[$lang.'/admin/download/edit/(:num)'] = 'admin/editdownload/$2';
+$route[$lang.'/admin/download/add'] = 'admin/adddownload';
+$route[$lang.'/admin/download/update'] = 'admin/updatedownload';
+$route[$lang.'/admin/download/delete'] = 'admin/deletedownload';
+
 /*Changelog*/
 $route[$lang.'/changelogs'] = 'changelogs/index';
 

--- a/application/language/english/admin_lang.php
+++ b/application/language/english/admin_lang.php
@@ -57,6 +57,7 @@ $lang['admin_nav_manage_store'] = 'Manage Store';
 $lang['admin_nav_forum'] = 'Forum';
 $lang['admin_nav_manage_forum'] = 'Manage Forum';
 $lang['admin_nav_logs'] = 'Logs System';
+$lang['admin_nav_download'] = 'Download';
 
 /*Sections Lang*/
 $lang['section_general_settings'] = 'General Settings';
@@ -130,6 +131,9 @@ $lang['placeholder_create_topsite'] = 'Create Topsite';
 $lang['placeholder_edit_topsite'] = 'Edit Topsite';
 $lang['placeholder_create_top'] = 'Create TOP Item';
 $lang['placeholder_edit_top'] = 'Edit TOP Item';
+$lang['placeholder_select_category'] = 'Select a Category';
+$lang['placeholder_create_download'] = 'Create Download';
+$lang['placeholder_edit_download'] = 'Edit Download';
 
 $lang['placeholder_upload_image'] = 'Upload Image';
 $lang['placeholder_icon_name'] = 'Icon Name';
@@ -160,6 +164,8 @@ $lang['placeholder_account_grant_rank'] = 'Grant GM Rank';
 $lang['placeholder_account_remove_rank'] = 'Remove GM Rank';
 $lang['placeholder_command'] = 'Command';
 $lang['placeholder_emulator'] = 'Emulator';
+$lang['placeholder_size'] = 'Size';
+$lang['placeholder_select_type'] = 'Select a Type';
 
 /*Config Lang*/
 $lang['conf_website_name'] = 'Website Name';

--- a/application/language/english/general_lang.php
+++ b/application/language/english/general_lang.php
@@ -53,6 +53,7 @@ $lang['tab_reset'] = 'Password Recovery';
 $lang['tab_error'] = 'Error 404';
 $lang['tab_maintenance'] = 'Maintenance';
 $lang['tab_online'] = 'Online Players';
+$lang['tab_download'] = 'Download';
 
 /*Panel Navbar*/
 $lang['navbar_vote_panel'] = 'Vote Panel';

--- a/application/language/spanish/admin_lang.php
+++ b/application/language/spanish/admin_lang.php
@@ -57,6 +57,7 @@ $lang['admin_nav_manage_store'] = 'Administrar Tienda';
 $lang['admin_nav_forum'] = 'Foro';
 $lang['admin_nav_manage_forum'] = 'Administrar Foro';
 $lang['admin_nav_logs'] = 'Sistema de Logs';
+$lang['admin_nav_download'] = 'Descargas';
 
 /*Sections Lang*/
 $lang['section_general_settings'] = 'Configuración General';
@@ -130,6 +131,9 @@ $lang['placeholder_create_topsite'] = 'Crear Topsite';
 $lang['placeholder_edit_topsite'] = 'Editar Topsite';
 $lang['placeholder_create_top'] = 'Crear TOP Item';
 $lang['placeholder_edit_top'] = 'Editar TOP Item';
+$lang['placeholder_select_category'] = 'Selecciona una Categoría';
+$lang['placeholder_create_download'] = 'Crear una Descarga';
+$lang['placeholder_edit_download'] = 'Editar Descarga';
 
 $lang['placeholder_upload_image'] = 'Cargar imagen';
 $lang['placeholder_icon_name'] = 'Nombre del icono';
@@ -160,6 +164,8 @@ $lang['placeholder_account_grant_rank'] = 'Otorgar Rango GM';
 $lang['placeholder_account_remove_rank'] = 'Remover Rango GM';
 $lang['placeholder_command'] = 'Comando';
 $lang['placeholder_emulator'] = 'Emulador';
+$lang['placeholder_size'] = 'Tamaño';
+$lang['placeholder_select_type'] = 'Selecciona un Tipo';
 
 /*Config Lang*/
 $lang['conf_website_name'] = 'Nombre del Sitio Web';

--- a/application/language/spanish/general_lang.php
+++ b/application/language/spanish/general_lang.php
@@ -53,6 +53,7 @@ $lang['tab_reset'] = 'Recuperación de contraseña';
 $lang['tab_error'] = 'Error 404';
 $lang['tab_maintenance'] = 'Mantenimiento';
 $lang['tab_online'] = 'Jugadores en linea';
+$lang['tab_download'] = 'Descargas';
 
 /*Panel Navbar*/
 $lang['navbar_vote_panel'] = 'Panel de Votos';

--- a/application/migrations/015_create_modules.php
+++ b/application/migrations/015_create_modules.php
@@ -44,6 +44,7 @@ class Migration_create_modules extends CI_Migration {
         array('name' => 'PvP', 'status' => '1'),
         array('name' => 'Bugtracker', 'status' => '1'),
         array('name' => 'Changelogs', 'status' => '1'),
+        array('name' => 'Download', 'status' => '1'),
      );
      $this->db->insert_batch('modules', $data);
 

--- a/application/migrations/039_create_download.php
+++ b/application/migrations/039_create_download.php
@@ -1,0 +1,53 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_create_download extends CI_Migration {
+
+    public function up()
+    {
+      $this->dbforge->add_field(array(
+              'id' => array(
+                      'type' => 'INT',
+                      'constraint' => '10',
+                      'unsigned' => TRUE,
+                      'auto_increment' => TRUE
+              ),
+              'fileName' => array(
+                      'type' => 'VARCHAR',
+                      'constraint' => '100'
+              ),
+              'type' => array(
+                      'type' => 'VARCHAR',
+					  'constraint' => '10',
+                      'null' => FALSE
+              ),
+              'weight' => array(
+                      'type' => 'VARCHAR',
+                      'constraint' => '100'
+              ),
+              'category' => array(
+                      'type' => 'INT',
+                      'constraint' => '10',
+                      'unsigned' => TRUE,
+                      'default' => '1'
+              ),
+              'image' => array(
+                      'type' => 'TEXT',
+                      'unsigned' => TRUE
+              ),
+              'url' => array(
+                      'type' => 'TEXT',
+                      'unsigned' => TRUE
+              ),
+      ));
+      $this->dbforge->add_key('id', TRUE);
+      $this->dbforge->create_table('download');
+      
+    }
+
+    public function down()
+    {
+      $this->dbforge->drop_table('download');
+    }
+}

--- a/application/models/Module_model.php
+++ b/application/models/Module_model.php
@@ -182,4 +182,14 @@ class Module_model extends CI_Model {
         else
             return false;
     }
+	
+	public function getDownloadStatus()
+    {
+        $qq = $this->db->select('status')->where('id', '18')->get($this->modules_table)->row('status');
+
+        if($qq == '1')
+            return true;
+        else
+            return false;
+    }
 }

--- a/application/modules/admin/controllers/Admin.php
+++ b/application/modules/admin/controllers/Admin.php
@@ -1362,4 +1362,74 @@ class Admin extends MX_Controller {
             echo $this->wowrealm->commandSoap('.server info', $charsMultiRealm->console_username, $charsMultiRealm->console_password, $charsMultiRealm->console_hostname, $charsMultiRealm->console_port, $charsMultiRealm->emulator).'<br>';
         }
     }
+	
+	/**
+	* Download
+	**/
+	
+	public function managedownload()
+    {
+        $data = array(
+            'pagetitle' => $this->lang->line('button_admin_panel'),
+            'lang' => $this->lang->lang()
+        );
+
+        $this->template->build('download/managedownload', $data);
+    }
+	
+	public function createdownload()
+    {
+        $data = array(
+            'pagetitle' => $this->lang->line('button_admin_panel'),
+            'lang' => $this->lang->lang()
+        );
+
+        $this->template->build('download/create_download', $data);
+    }
+
+    public function editdownload($id)
+    {
+        if (is_null($id) || empty($id))
+            redirect(base_url(),'refresh');
+
+        if ($this->admin_model->getDownloadSpecifyRows($id) < 1)
+            redirect(base_url(),'refresh');
+
+        $data = array(
+            'pagetitle' => $this->lang->line('button_admin_panel'),
+            'idlink' => $id,
+            'lang' => $this->lang->lang()
+        );
+
+        $this->template->build('download/edit_download', $data);
+    }
+
+    public function adddownload()
+    {
+        $fileName = $this->input->post('fileName');
+        $url = $this->input->post('url');
+        $image = $this->input->post('image');
+        $category = $this->input->post('category');
+        $weight = $this->input->post('weight');
+        $type = $this->input->post('type');
+        echo $this->admin_model->insertDownload($fileName, $url, $image, $category, $weight, $type);
+    }
+
+    public function updatedownload()
+    {
+        $id = $this->input->post('id');
+        $fileName = $this->input->post('fileName');
+        $url = $this->input->post('url');
+        $image = $this->input->post('image');
+        $category = $this->input->post('category');
+        $weight = $this->input->post('weight');
+        $type = $this->input->post('type');
+        echo $this->admin_model->updateSpecifyDownload($id, $fileName, $url, $image, $category, $weight, $type);
+    }
+
+    public function deletedownload()
+    {
+        $id = $this->input->post('value');
+        echo $this->admin_model->delSpecifyDownload($id);
+    }
 }

--- a/application/modules/admin/models/Admin_model.php
+++ b/application/modules/admin/models/Admin_model.php
@@ -1284,4 +1284,85 @@ class Admin_model extends CI_Model {
     {
         return $this->db->select('name')->where('id', $id)->get('forum_category')->row('name');
     }
+
+    /**
+    * Download
+    **/
+    
+    public function getDownload()
+    {
+        return $this->db->select('*')->get('download')->result();
+    }
+    
+    public function getDownloadSpecifyRows($id)
+    {
+        return $this->db->select('*')->where('id', $id)->get('download')->num_rows();
+    }
+    
+    public function insertDownload($fileName, $url, $image, $category, $weight, $type)
+    {
+        $data = array(
+            'fileName' => $fileName,
+            'url' => $url,
+            'image' => $image,
+            'category' => $category,
+            'weight' => $weight,
+            'type' => $type
+        );
+
+        $this->db->insert('download', $data);
+        return true;
+    }
+
+    public function delSpecifyDownload($id)
+    {
+        $this->db->where('id', $id)->delete('download');
+        return true;
+    }
+    
+    public function updateSpecifyDownload($id, $fileName, $url, $image, $category, $weight, $type)
+    {
+        $update = array(
+            'id' => $id,
+            'fileName' => $fileName,
+            'url' => $url,
+            'image' => $image,
+            'category' => $category,
+            'weight' => $weight,
+            'type' => $type
+        );
+
+        $this->db->where('id', $id)->update('download', $update);
+        return true;
+    }
+
+    public function getDownloadSpecifyfileName($id)
+    {
+        return $this->db->select('fileName')->where('id', $id)->get('download')->row('fileName');
+    }
+
+    public function getDownloadSpecifyUrl($id)
+    {
+        return $this->db->select('url')->where('id', $id)->get('download')->row('url');
+    }
+
+    public function getDownloadSpecifyImage($id)
+    {
+        return $this->db->select('image')->where('id', $id)->get('download')->row('image');
+    }
+
+    public function getDownloadSpecifyCategory($id)
+    {
+        return $this->db->select('category')->where('id', $id)->get('download')->row('category');
+    }
+
+    public function getDownloadSpecifyWeight($id)
+    {
+        return $this->db->select('weight')->where('id', $id)->get('download')->row('weight');
+    }
+
+    public function getDownloadSpecifyType($id)
+    {
+        return $this->db->select('type')->where('id', $id)->get('download')->row('type');
+    }
 }

--- a/application/modules/admin/views/download/create_download.php
+++ b/application/modules/admin/views/download/create_download.php
@@ -1,0 +1,176 @@
+ <section class="uk-section uk-section-xsmall" data-uk-height-viewport="expand: true">
+      <div class="uk-container">
+        <div class="uk-grid uk-grid-small uk-margin-small" data-uk-grid>
+          <div class="uk-width-expand uk-heading-line">
+            <h3 class="uk-h3"><i class="fas fa-download"></i> <?= $this->lang->line('placeholder_create_download'); ?></h3>
+          </div>
+          <div class="uk-width-auto">
+            <a href="<?= base_url('admin/download'); ?>" class="uk-icon-button"><i class="fas fa-arrow-circle-left"></i></a>
+          </div>
+        </div>
+        <div class="uk-card uk-card-default">
+          <div class="uk-card-body">
+            <?= form_open('', 'id="adddownloadForm" onsubmit="AddDownloadForm(event)"'); ?>
+            <div class="uk-margin-small">
+              <div class="uk-grid-small" uk-grid>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('placeholder_name'); ?></label>
+                  <div class="uk-form-controls">
+                    <div class="uk-inline uk-width-1-1">
+                      <span class="uk-form-icon uk-form-icon-flip"><i class="fas fa-pen"></i></span>
+                      <input class="uk-input" type="text" id="down_name" placeholder="<?= $this->lang->line('placeholder_name'); ?>" required>
+                    </div>
+                  </div>
+                </div>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('placeholder_url'); ?></label>
+                  <div class="uk-form-controls">
+                    <div class="uk-inline uk-width-1-1">
+                      <span class="uk-form-icon uk-form-icon-flip"><i class="fas fa-link"></i></span>
+                      <input class="uk-input" type="text" id="down_url" placeholder="<?= $this->lang->line('placeholder_url'); ?>" required>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="uk-margin-small">
+              <div class="uk-grid-small" uk-grid>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('option_image'); ?></label>
+                  <div class="uk-form-controls">
+                    <div class="uk-inline uk-width-1-1">
+                      <span class="uk-form-icon uk-form-icon-flip"><i class="fab fa-font-awesome-flag"></i></span>
+                      <input class="uk-input" type="text" id="down_image" placeholder="<?= $this->lang->line('option_image'); ?>" required>
+                    </div>
+                  </div>
+                </div>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('placeholder_category'); ?></label>
+                  <div class="uk-form-controls">
+                    <select class="uk-select" id="down_category">
+                      <option value="0"><?= $this->lang->line('placeholder_select_category'); ?></option>
+                      <option value="1">Client</option>
+                      <option value="2">Addon</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="uk-margin-small">
+              <div class="uk-grid-small" uk-grid>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('placeholder_size'); ?></label>
+                  <div class="uk-form-controls">
+                    <div class="uk-inline uk-width-1-1">
+                      <span class="uk-form-icon uk-form-icon-flip"></span>
+                      <input class="uk-input" type="text" id="down_size" placeholder="1 GB" required>
+                    </div>
+                  </div>
+                </div>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('placeholder_size'); ?></label>
+                  <div class="uk-form-controls">
+                    <select class="uk-select" id="down_type">
+                      <option value="0"><?= $this->lang->line('placeholder_select_type'); ?></option>
+                      <option value="Rar">Rar</option>
+                      <option value="Zip">Zip</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="uk-margin-small">
+              <button class="uk-button uk-button-primary uk-width-1-1" type="submit" id="button_download"><i class="fas fa-check-circle"></i> <?= $this->lang->line('button_create'); ?></button>
+            </div>
+            <?= form_close(); ?>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <script>
+      function AddDownloadForm(e) {
+        e.preventDefault();
+
+        var fileName = $.trim($('#down_name').val());
+        var url = $.trim($('#down_url').val());
+        var image = $.trim($('#down_image').val());
+        var category = $.trim($('#down_category').val());
+        var weight = $.trim($('#down_size').val());
+        var type = $.trim($('#down_type').val());
+        if(fileName == ''){
+          $.amaran({
+            'theme': 'awesome error',
+            'content': {
+              title: '<?= $this->lang->line('notification_title_error'); ?>',
+              message: '<?= $this->lang->line('notification_name_empty'); ?>',
+              info: '',
+              icon: 'fas fa-times-circle'
+            },
+            'delay': 5000,
+            'position': 'top right',
+            'inEffect': 'slideRight',
+            'outEffect': 'slideRight'
+          });
+          return false;
+        }
+        if(category == 0 || type == 0){
+          $.amaran({
+            'theme': 'awesome error',
+            'content': {
+              title: '<?= $this->lang->line('notification_title_error'); ?>',
+              message: '<?= $this->lang->line('notification_select_type'); ?>',
+              info: '',
+              icon: 'fas fa-times-circle'
+            },
+            'delay': 5000,
+            'position': 'top right',
+            'inEffect': 'slideRight',
+            'outEffect': 'slideRight'
+          });
+          return false;
+        }
+        $.ajax({
+          url:"<?= base_url($lang.'/admin/download/add'); ?>",
+          method:"POST",
+          data:{fileName, url, image, category, weight, type},
+          dataType:"text",
+          beforeSend: function(){
+            $.amaran({
+              'theme': 'awesome info',
+              'content': {
+                title: '<?= $this->lang->line('notification_title_info'); ?>',
+                message: '<?= $this->lang->line('notification_checking'); ?>',
+                info: '',
+                icon: 'fas fa-sign-in-alt'
+              },
+              'delay': 5000,
+              'position': 'top right',
+              'inEffect': 'slideRight',
+              'outEffect': 'slideRight'
+            });
+          },
+          success:function(response){
+            if(!response)
+              alert(response);
+
+            if (response) {
+              $.amaran({
+                'theme': 'awesome ok',
+                  'content': {
+                  title: '<?= $this->lang->line('notification_title_success'); ?>',
+                  message: '<?= $this->lang->line('notification_menu_created'); ?>',
+                  info: '',
+                  icon: 'fas fa-check-circle'
+                },
+                'delay': 5000,
+                'position': 'top right',
+                'inEffect': 'slideRight',
+                'outEffect': 'slideRight'
+              });
+            }
+            $('#adddownloadForm')[0].reset();
+          }
+        });
+      }
+    </script>

--- a/application/modules/admin/views/download/edit_download.php
+++ b/application/modules/admin/views/download/edit_download.php
@@ -1,0 +1,178 @@
+<section class="uk-section uk-section-xsmall" data-uk-height-viewport="expand: true">
+      <div class="uk-container">
+        <div class="uk-grid uk-grid-small uk-margin-small" data-uk-grid>
+          <div class="uk-width-expand uk-heading-line">
+            <h3 class="uk-h3"><i class="fas fa-edit"></i> <?= $this->lang->line('placeholder_edit_download'); ?></h3>
+          </div>
+          <div class="uk-width-auto">
+            <a href="<?= base_url('admin/download'); ?>" class="uk-icon-button"><i class="fas fa-arrow-circle-left"></i></a>
+          </div>
+        </div>
+        <div class="uk-card uk-card-default">
+          <div class="uk-card-body">
+            <?= form_open('', 'id="updatedownloadForm" onsubmit="UpdateDownloadForm(event)"'); ?>
+            <div class="uk-margin-small">
+              <div class="uk-grid-small" uk-grid>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('placeholder_name'); ?></label>
+                  <div class="uk-form-controls">
+                    <div class="uk-inline uk-width-1-1">
+                      <span class="uk-form-icon uk-form-icon-flip"><i class="fas fa-pen"></i></span>
+                      <input class="uk-input" type="text" id="down_name" value="<?= $this->admin_model->getDownloadSpecifyfileName($idlink); ?>" placeholder="<?= $this->lang->line('placeholder_name'); ?>" required>
+                    </div>
+                  </div>
+                </div>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('placeholder_url'); ?></label>
+                  <div class="uk-form-controls">
+                    <div class="uk-inline uk-width-1-1">
+                      <span class="uk-form-icon uk-form-icon-flip"><i class="fas fa-link"></i></span>
+                      <input class="uk-input" type="text" id="down_url" value="<?= $this->admin_model->getDownloadSpecifyUrl($idlink); ?>" placeholder="<?= $this->lang->line('placeholder_url'); ?>" required>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="uk-margin-small">
+              <div class="uk-grid-small" uk-grid>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('option_image'); ?></label>
+                  <div class="uk-form-controls">
+                    <div class="uk-inline uk-width-1-1">
+                      <span class="uk-form-icon uk-form-icon-flip"><i class="fab fa-font-awesome-flag"></i></span>
+                      <input class="uk-input" type="text" id="down_image" value="<?= $this->admin_model->getDownloadSpecifyImage($idlink); ?>" placeholder="<?= $this->lang->line('option_image'); ?>" required>
+                    </div>
+                  </div>
+                </div>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('placeholder_category'); ?></label>
+                  <div class="uk-form-controls">
+                    <select class="uk-select" id="down_category">
+                      <option value="0"><?= $this->lang->line('placeholder_select_category'); ?></option>
+                      <option value="1" <?php if($this->admin_model->getDownloadSpecifyCategory($idlink) == '1') echo 'selected'; ?>>Client</option>
+                      <option value="2" <?php if($this->admin_model->getDownloadSpecifyCategory($idlink) == '2') echo 'selected'; ?>>Addon</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="uk-margin-small">
+              <div class="uk-grid-small" uk-grid>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('placeholder_size'); ?></label>
+                  <div class="uk-form-controls">
+                    <div class="uk-inline uk-width-1-1">
+                      <span class="uk-form-icon uk-form-icon-flip"><i class="fas fa-bars"></i></span>
+                      <input class="uk-input" type="text" id="down_weight" value="<?= $this->admin_model->getDownloadSpecifyWeight($idlink); ?>" placeholder="1 BG" required>
+                    </div>
+                  </div>
+                </div>
+                <div class="uk-inline uk-width-1-2@s">
+                  <label class="uk-form-label"><?= $this->lang->line('placeholder_type'); ?></label>
+                  <div class="uk-form-controls">
+                    <select class="uk-select" id="down_type">
+                      <option value="0"><?= $this->lang->line('notification_select_type'); ?></option>
+                      <option value="Rar" <?php if($this->admin_model->getDownloadSpecifyType($idlink) == 'Rar') echo 'selected'; ?>>Rar</option>
+                      <option value="Zip" <?php if($this->admin_model->getDownloadSpecifyType($idlink) == 'Zip') echo 'selected'; ?>>Zip</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="uk-margin-small">
+              <button class="uk-button uk-button-primary uk-width-1-1" type="submit" id="button_download"><i class="fas fa-sync-alt"></i> <?= $this->lang->line('button_save'); ?></button>
+            </div>
+            <?= form_close(); ?>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <script>
+      function UpdateDownloadForm(e) {
+        e.preventDefault();
+
+        var id = "<?= $idlink ?>";
+        var fileName = $.trim($('#down_name').val());
+        var url = $.trim($('#down_url').val());
+        var image = $.trim($('#down_image').val());
+        var category = $.trim($('#down_category').val());
+        var weight = $.trim($('#down_weight').val());
+        var type = $.trim($('#down_type').val());
+        if(fileName == ''){
+          $.amaran({
+            'theme': 'awesome error',
+            'content': {
+              title: '<?= $this->lang->line('notification_title_error'); ?>',
+              message: '<?= $this->lang->line('notification_name_empty'); ?>',
+              info: '',
+              icon: 'fas fa-times-circle'
+            },
+            'delay': 5000,
+            'position': 'top right',
+            'inEffect': 'slideRight',
+            'outEffect': 'slideRight'
+          });
+          return false;
+        }
+        if(category == 0 || type == 0){
+          $.amaran({
+            'theme': 'awesome error',
+            'content': {
+              title: '<?= $this->lang->line('notification_title_error'); ?>',
+              message: '<?= $this->lang->line('notification_select_type'); ?>',
+              info: '',
+              icon: 'fas fa-times-circle'
+            },
+            'delay': 5000,
+            'position': 'top right',
+            'inEffect': 'slideRight',
+            'outEffect': 'slideRight'
+          });
+          return false;
+        }
+        $.ajax({
+          url:"<?= base_url($lang.'/admin/download/update'); ?>",
+          method:"POST",
+          data:{id, fileName, url, image, category, weight, type},
+          dataType:"text",
+          beforeSend: function(){
+            $.amaran({
+              'theme': 'awesome info',
+              'content': {
+                title: '<?= $this->lang->line('notification_title_info'); ?>',
+                message: '<?= $this->lang->line('notification_checking'); ?>',
+                info: '',
+                icon: 'fas fa-sign-in-alt'
+              },
+              'delay': 5000,
+              'position': 'top right',
+              'inEffect': 'slideRight',
+              'outEffect': 'slideRight'
+            });
+          },
+          success:function(response){
+            if(!response)
+              alert(response);
+
+            if (response) {
+              $.amaran({
+                'theme': 'awesome ok',
+                  'content': {
+                  title: '<?= $this->lang->line('notification_title_success'); ?>',
+                  message: '<?= $this->lang->line('notification_menu_edited'); ?>',
+                  info: '',
+                  icon: 'fas fa-check-circle'
+                },
+                'delay': 5000,
+                'position': 'top right',
+                'inEffect': 'slideRight',
+                'outEffect': 'slideRight'
+              });
+            }
+            $('#updatedownloadForm')[0].reset();
+            window.location.replace("<?= base_url('admin/download/edit/'.$idlink); ?>");
+          }
+        });
+      }
+    </script>

--- a/application/modules/admin/views/download/managedownload.php
+++ b/application/modules/admin/views/download/managedownload.php
@@ -1,0 +1,92 @@
+<section class="uk-section uk-section-xsmall" data-uk-height-viewport="expand: true">
+      <div class="uk-container">
+        <div class="uk-grid uk-grid-small uk-margin-small" data-uk-grid>
+          <div class="uk-width-expand uk-heading-line">
+            <h3 class="uk-h3"><i class="fas fa-download"></i> <?= $this->lang->line('admin_nav_download'); ?></h3>
+          </div>
+          <div class="uk-width-auto">
+            <a href="<?= base_url('admin/download/create'); ?>" class="uk-icon-button"><i class="fas fa-pen"></i></a>
+          </div>
+        </div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <div class="uk-overflow-auto">
+            <table class="uk-table uk-table-middle uk-table-divider uk-table-small">
+              <thead>
+                <tr>
+                  <th class="uk-table-shrink"><?= $this->lang->line('table_header_id'); ?></th>
+                  <th class="uk-width-small"><?= $this->lang->line('placeholder_name'); ?></th>
+                  <th class="uk-width-medium"><?= $this->lang->line('placeholder_url'); ?></th>
+                  <th class="uk-width-small"><?= $this->lang->line('placeholder_category'); ?></th>
+                  <th class="uk-width-small uk-text-center"><?= $this->lang->line('table_header_actions'); ?></th>
+                </tr>
+              </thead>
+              <tbody>
+                <?php foreach($this->admin_model->getDownload() as $download): ?>
+                <tr>
+                  <td><?= $download->id ?></td>
+                  <td><?= $download->fileName ?></td>
+                  <td><?= $download->url ?></td>
+                  <td><?= $download->category ?></td>
+                  <td>
+                    <div class="uk-flex uk-flex-left uk-flex-center@m uk-margin-small">
+                      <a href="<?= base_url('admin/download/edit/'.$download->id); ?>" class="uk-button uk-button-primary uk-margin-small-right"><i class="fas fa-edit"></i></a>
+                      <button class="uk-button uk-button-danger" value="<?= $download->id ?>" id="button_delete<?= $download->id ?>" onclick="DeleteDownload(event, this.value)"><i class="fas fa-trash-alt"></i></button>
+                    </div>
+                  </td>
+                </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <script>
+      function DeleteDownload(e, value) {
+        e.preventDefault();
+
+        $.ajax({
+          url:"<?= base_url($lang.'/admin/download/delete'); ?>",
+          method:"POST",
+          data:{value},
+          dataType:"text",
+          beforeSend: function(){
+            $.amaran({
+              'theme': 'awesome info',
+              'content': {
+                title: '<?= $this->lang->line('notification_title_info'); ?>',
+                message: '<?= $this->lang->line('notification_checking'); ?>',
+                info: '',
+                icon: 'fas fa-sign-in-alt'
+              },
+              'delay': 5000,
+              'position': 'top right',
+              'inEffect': 'slideRight',
+              'outEffect': 'slideRight'
+            });
+          },
+          success:function(response){
+            if(!response)
+              alert(response);
+
+            if (response) {
+              $.amaran({
+                'theme': 'awesome ok',
+                  'content': {
+                  title: '<?= $this->lang->line('notification_title_success'); ?>',
+                  message: '<?= $this->lang->line('notification_menu_deleted'); ?>',
+                  info: '',
+                  icon: 'fas fa-check-circle'
+                },
+                'delay': 5000,
+                'position': 'top right',
+                'inEffect': 'slideRight',
+                'outEffect': 'slideRight'
+              });
+            }
+            window.location.replace("<?= base_url('admin/download'); ?>");
+          }
+        });
+      }
+    </script>

--- a/application/modules/bugtracker/views/index.php
+++ b/application/modules/bugtracker/views/index.php
@@ -26,6 +26,10 @@
               <?php if($this->wowmodule->getChangelogsStatus() == '1'): ?>
               <li><a href="<?= base_url('changelogs'); ?>"><i class="fas fa-scroll"></i> <?=$this->lang->line('tab_changelogs'); ?></a></li>
               <?php endif; ?>
+              <?php endif; ?>
+              <?php if($this->wowmodule->getDownloadStatus() == '1'): ?>
+              <li><a href="<?= base_url('download'); ?>"><i class="fas fa-download"></i> <?=$this->lang->line('tab_download'); ?></a></li>
+              <?php endif; ?>
             </ul>
           </div>
           <div class="uk-width-3-4@m">

--- a/application/modules/changelogs/views/index.php
+++ b/application/modules/changelogs/views/index.php
@@ -26,6 +26,9 @@
               <?php if($this->wowmodule->getChangelogsStatus() == '1'): ?>
               <li class="uk-active"><a href="<?= base_url('changelogs'); ?>"><i class="fas fa-scroll"></i> <?=$this->lang->line('tab_changelogs'); ?></a></li>
               <?php endif; ?>
+              <?php if($this->wowmodule->getDownloadStatus() == '1'): ?>
+              <li><a href="<?= base_url('download'); ?>"><i class="fas fa-download"></i> <?=$this->lang->line('tab_download'); ?></a></li>
+              <?php endif; ?>
             </ul>
           </div>
           <div class="uk-width-3-4@m">

--- a/application/modules/donate/views/index.php
+++ b/application/modules/donate/views/index.php
@@ -31,6 +31,9 @@ endif; ?>
               <?php if($this->wowmodule->getChangelogsStatus() == '1'): ?>
               <li><a href="<?= base_url('changelogs'); ?>"><i class="fas fa-scroll"></i> <?=$this->lang->line('tab_changelogs'); ?></a></li>
               <?php endif; ?>
+              <?php if($this->wowmodule->getDownloadStatus() == '1'): ?>
+              <li><a href="<?= base_url('download'); ?>"><i class="fas fa-download"></i> <?=$this->lang->line('tab_download'); ?></a></li>
+              <?php endif; ?>
             </ul>
           </div>
           <div class="uk-width-3-4@m">

--- a/application/modules/download/controllers/Download.php
+++ b/application/modules/download/controllers/Download.php
@@ -1,0 +1,68 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+/**
+ * BlizzCMS
+ *
+ * An Open Source CMS for "World of Warcraft"
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2017 - 2019, WoW-CMS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author  WoW-CMS
+ * @copyright  Copyright (c) 2017 - 2019, WoW-CMS.
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link    https://wow-cms.com
+ * @since   Version 1.0.1
+ * @filesource
+ */
+
+class Download extends MX_Controller {
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model('download_model');
+
+        if(!ini_get('date.timezone'))
+           date_default_timezone_set($this->config->item('timezone'));
+
+        if(!$this->wowgeneral->getMaintenance())
+            redirect(base_url('maintenance'),'refresh');
+		
+		if (!$this->wowmodule->getDownloadStatus())
+            redirect(base_url(),'refresh');
+
+        if (!$this->wowauth->isLogged())
+            redirect(base_url('login'),'refresh');
+    }
+
+    public function index()
+    {
+
+        $data = array(
+		
+            'pagetitle' => 'Download Center',
+        );
+
+        $this->template->build('index', $data);
+    }
+}

--- a/application/modules/download/controllers/index.html
+++ b/application/modules/download/controllers/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/application/modules/download/index.html
+++ b/application/modules/download/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/application/modules/download/models/Download_model.php
+++ b/application/modules/download/models/Download_model.php
@@ -1,0 +1,24 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Download_model extends CI_Model {
+
+    /**
+     * Download_model constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+	
+	public function getGame()
+    {
+        return $this->db->select('*')->where('category', '1')->order_by('id', 'ASC')->get('download');
+    }
+	
+	public function getAddons()
+    {
+        return $this->db->select('*')->where('category', '2')->order_by('id', 'ASC')->get('download');
+    }
+	
+}

--- a/application/modules/download/models/index.html
+++ b/application/modules/download/models/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/application/modules/download/views/index.html
+++ b/application/modules/download/views/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/application/modules/download/views/index.php
+++ b/application/modules/download/views/index.php
@@ -1,0 +1,78 @@
+<section class="uk-section uk-section-xsmall uk-padding-remove slider-section">
+	<div class="uk-background-cover uk-height-small header-section"></div>
+</section>
+<section class="uk-section uk-section-xsmall main-section" data-uk-height-viewport="expand: true">
+	<div class="uk-container">
+		<div class="uk-grid uk-grid-medium" data-uk-grid>
+			<div class="uk-width-1-1">
+				<div class="uk-width-auto">
+					<h4 class="uk-h4 uk-text-uppercase uk-text-bold"><i class="fas fa-download"></i> Download</h4>
+				</div>
+				<div class="uk-width-expand@s">
+					<div class="uk-child-width-1-1" uk-grid>
+						<div>
+							<div uk-grid>
+								<div class="uk-width-auto@m">
+									<ul class="uk-tab-left" uk-tab="connect: #component-tab-left; animation: uk-animation-slide-left-medium, uk-animation-slide-right-medium">
+										<li><a href="#">Client</a></li>
+										<li><a href="#">Addons</a></li>
+									</ul>
+								</div>
+								<div class="uk-width-expand@m">
+									<ul id="component-tab-left" class="uk-switcher">
+										<li>
+											<table class="uk-table uk-table-middle uk-table-divider">
+												<thead>
+													<tr>
+														<th class="uk-width-small">Version</th>
+														<th class="uk-width-medium">Name</th>
+														<th>Size</th>
+														<th>Type</th>
+														<th>Download</th>
+													</tr>
+												</thead>
+												<tbody>
+													<?php foreach ($this->download_model->getGame()->result() as $files): ?>
+													<tr>
+														<td><div style="background:url(<?=base_url('assets/images/forums/wow-icons/' . $files->image);?>); width: 50px; height: 50px;)"></div></td>
+														<td><?=$files->fileName?></td>
+														<td><?=$files->weight?></td>
+														<td><?=$files->type?></td>
+														<td><a class="uk-button uk-label-success uk-button-small" href="<?=$files->url?>" target="_blank"><i class="fas fa-download"></i> Download</a></td>
+													</tr>
+													<?php endforeach;?>
+												</tbody>
+											</table>
+										</li>
+										<li>
+											<table class="uk-table uk-table-middle uk-table-divider">
+												<thead>
+													<tr>
+														<th class="uk-width-small">Version</th>
+														<th class="uk-width-large">Name</th>
+														<th>Size</th>
+														<th>Download</th>
+													</tr>
+												</thead>
+												<tbody>
+													<?php foreach ($this->download_model->getAddons()->result() as $files): ?>
+													<tr>
+														<td><div style="background:url(<?=base_url('assets/images/forums/wow-icons/' . $files->image);?>); width: 50px; height: 50px;)"></div></td>
+														<td><?=$files->fileName?></td>
+														<td><?=$files->weight?></td>
+														<td><a class="uk-button uk-label-success uk-button-small" href="<?=$files->url?>" target="_blank"><i class="fas fa-download"></i> Download</a></td>
+													</tr>
+													<?php endforeach;?>
+												</tbody>
+											</table>
+										</li>
+									</ul>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</section>

--- a/application/modules/user/views/panel.php
+++ b/application/modules/user/views/panel.php
@@ -26,6 +26,9 @@
               <?php if($this->wowmodule->getChangelogsStatus() == '1'): ?>
               <li><a href="<?= base_url('changelogs'); ?>"><i class="fas fa-scroll"></i> <?=$this->lang->line('tab_changelogs'); ?></a></li>
               <?php endif; ?>
+              <?php if($this->wowmodule->getDownloadStatus() == '1'): ?>
+              <li><a href="<?= base_url('download'); ?>"><i class="fas fa-download"></i> <?=$this->lang->line('tab_download'); ?></a></li>
+              <?php endif; ?>
             </ul>
           </div>
           <div class="uk-width-3-4@m">

--- a/application/modules/vote/views/index.php
+++ b/application/modules/vote/views/index.php
@@ -6,44 +6,47 @@
         <div class="uk-grid uk-grid-medium" data-uk-grid>
           <div class="uk-width-1-4@m">
             <ul class="uk-nav uk-nav-default myaccount-nav">
-              <?php if($this->wowmodule->getUCPStatus() == '1'): ?>
-              <li><a href="<?= base_url('panel'); ?>"><i class="fas fa-user-circle"></i> <?= $this->lang->line('tab_account'); ?></a></li>
-              <?php endif; ?>
+              <?php if ($this->wowmodule->getUCPStatus() == '1'): ?>
+              <li><a href="<?=base_url('panel');?>"><i class="fas fa-user-circle"></i> <?=$this->lang->line('tab_account');?></a></li>
+              <?php endif;?>
               <li class="uk-nav-divider"></li>
-              <?php if($this->wowmodule->getDonationStatus() == '1'): ?>
-              <li><a href="<?= base_url('donate'); ?>"><i class="fas fa-hand-holding-usd"></i> <?=$this->lang->line('navbar_donate_panel'); ?></a></li>
-              <?php endif; ?>
-              <?php if($this->wowmodule->getVoteStatus() == '1'): ?>
-              <li class="uk-active"><a href="<?= base_url('vote'); ?>"><i class="fas fa-vote-yea"></i> <?=$this->lang->line('navbar_vote_panel'); ?></a></li>
-              <?php endif; ?>
-              <?php if($this->wowmodule->getStoreStatus() == '1'): ?>
-              <li><a href="<?= base_url('store'); ?>"><i class="fas fa-store"></i> <?=$this->lang->line('tab_store'); ?></a></li>
-              <?php endif; ?>
+              <?php if ($this->wowmodule->getDonationStatus() == '1'): ?>
+              <li><a href="<?=base_url('donate');?>"><i class="fas fa-hand-holding-usd"></i> <?=$this->lang->line('navbar_donate_panel');?></a></li>
+              <?php endif;?>
+              <?php if ($this->wowmodule->getVoteStatus() == '1'): ?>
+              <li class="uk-active"><a href="<?=base_url('vote');?>"><i class="fas fa-vote-yea"></i> <?=$this->lang->line('navbar_vote_panel');?></a></li>
+              <?php endif;?>
+              <?php if ($this->wowmodule->getStoreStatus() == '1'): ?>
+              <li><a href="<?=base_url('store');?>"><i class="fas fa-store"></i> <?=$this->lang->line('tab_store');?></a></li>
+              <?php endif;?>
               <li class="uk-nav-divider"></li>
-              <?php if($this->wowmodule->getBugtrackerStatus() == '1'): ?>
-              <li><a href="<?= base_url('bugtracker'); ?>"><i class="fas fa-bug"></i> <?=$this->lang->line('tab_bugtracker'); ?></a></li>
-              <?php endif; ?>
-              <?php if($this->wowmodule->getChangelogsStatus() == '1'): ?>
-              <li><a href="<?= base_url('changelogs'); ?>"><i class="fas fa-scroll"></i> <?=$this->lang->line('tab_changelogs'); ?></a></li>
-              <?php endif; ?>
+              <?php if ($this->wowmodule->getBugtrackerStatus() == '1'): ?>
+              <li><a href="<?=base_url('bugtracker');?>"><i class="fas fa-bug"></i> <?=$this->lang->line('tab_bugtracker');?></a></li>
+              <?php endif;?>
+              <?php if ($this->wowmodule->getChangelogsStatus() == '1'): ?>
+              <li><a href="<?=base_url('changelogs');?>"><i class="fas fa-scroll"></i> <?=$this->lang->line('tab_changelogs');?></a></li>
+              <?php endif;?>
+              <?php if ($this->wowmodule->getDownloadStatus() == '1'): ?>
+              <li><a href="<?=base_url('download');?>"><i class="fas fa-download"></i> <?=$this->lang->line('tab_download');?></a></li>
+              <?php endif;?>
             </ul>
           </div>
           <div class="uk-width-3-4@m">
-            <h4 class="uk-h4 uk-text-uppercase uk-text-bold"><?=$this->lang->line('tab_vote'); ?></h4>
+            <h4 class="uk-h4 uk-text-uppercase uk-text-bold"><?=$this->lang->line('tab_vote');?></h4>
             <div class="uk-grid uk-grid-small uk-child-width-1-1 uk-child-width-1-4@s uk-child-width-1-4@m" data-uk-grid>
               <?php foreach ($voteList as $key => $voteList): ?>
               <div>
                 <div class="uk-card uk-card-vote">
                   <div class="uk-card-header">
-                    <h5 class="uk-h5 uk-text-uppercase uk-text-bold"><?= $voteList->name ?></h5>
+                    <h5 class="uk-h5 uk-text-uppercase uk-text-bold"><?=$voteList->name?></h5>
                   </div>
                   <div class="uk-card-body">
                     <div class="uk-flex uk-flex-center">
-                      <img src="<?= $voteList->image ?>" alt="<?= $voteList->name ?>">
+                      <img src="<?=$voteList->image?>" alt="<?=$voteList->name?>">
                     </div>
-                    <p class="uk-text-small uk-text-center uk-margin-small"><?= $voteList->points ?> <?= $this->lang->line('panel_vp'); ?></p>
-                    <h5 class="uk-h5 uk-text-uppercase uk-text-bold uk-text-center uk-margin-remove-bottom uk-margin-small-top"><?= $this->lang->line('vote_next_time'); ?></h5>
-                    <div class="uk-grid-collapse uk-child-width-auto uk-flex-center uk-margin-small-bottom" uk-grid uk-countdown="date: <?= date('c', $this->vote_model->getTimeLogExpired($voteList->id, $this->session->userdata('wow_sess_id'))); ?>">
+                    <p class="uk-text-small uk-text-center uk-margin-small"><?=$voteList->points?> <?=$this->lang->line('panel_vp');?></p>
+                    <h5 class="uk-h5 uk-text-uppercase uk-text-bold uk-text-center uk-margin-remove-bottom uk-margin-small-top"><?=$this->lang->line('vote_next_time');?></h5>
+                    <div class="uk-grid-collapse uk-child-width-auto uk-flex-center uk-margin-small-bottom" uk-grid uk-countdown="date: <?=date('c', $this->vote_model->getTimeLogExpired($voteList->id, $this->session->userdata('wow_sess_id')));?>">
                       <div>
                         <div class="uk-countdown-number uk-countdown-days"></div>
                       </div>
@@ -60,19 +63,19 @@
                         <div class="uk-countdown-number uk-countdown-seconds"></div>
                       </div>
                     </div>
-                    <?php if($this->wowgeneral->getTimestamp() >= $this->vote_model->getTimeLogExpired($voteList->id, $this->session->userdata('wow_sess_id'))): ?>
-                      <?= form_open(base_url('vote/votenow/'.$voteList->id)); ?>
-                        <button class="uk-button uk-button-default uk-width-1-1"><i class="fas fa-vote-yea"></i> <?= $this->lang->line('tab_vote'); ?></button>
-                      <?= form_close(); ?>
+                    <?php if ($this->wowgeneral->getTimestamp() >= $this->vote_model->getTimeLogExpired($voteList->id, $this->session->userdata('wow_sess_id'))): ?>
+                      <?=form_open(base_url('vote/votenow/' . $voteList->id));?>
+                        <button class="uk-button uk-button-default uk-width-1-1"><i class="fas fa-vote-yea"></i> <?=$this->lang->line('tab_vote');?></button>
+                      <?=form_close();?>
                     <?php else: ?>
-                      <?= form_open(); ?>
-                        <button class="uk-button uk-button-default uk-width-1-1" disabled><i class="fas fa-vote-yea"></i> <?= $this->lang->line('tab_vote'); ?></button>
-                      <?= form_close(); ?>
-                    <?php endif; ?>
+                      <?=form_open();?>
+                        <button class="uk-button uk-button-default uk-width-1-1" disabled><i class="fas fa-vote-yea"></i> <?=$this->lang->line('tab_vote');?></button>
+                      <?=form_close();?>
+                    <?php endif;?>
                   </div>
                 </div>
               </div>
-              <?php endforeach; ?>
+              <?php endforeach;?>
             </div>
           </div>
         </div>

--- a/application/themes/admin/views/layouts/layout.php
+++ b/application/themes/admin/views/layouts/layout.php
@@ -74,6 +74,7 @@
                   <li><a href="<?= base_url('admin/news'); ?>"><span class="admin-subnav-icon"><i class="fas fa-newspaper"></i></span><?= $this->lang->line('admin_nav_news'); ?></a></li>
                   <li><a href="<?= base_url('admin/changelogs'); ?>"><span class="admin-subnav-icon"><i class="fas fa-scroll"></i></span><?= $this->lang->line('admin_nav_changelogs'); ?></a></li>
                   <li><a href="<?= base_url('admin/pages'); ?>"><span class="admin-subnav-icon"><i class="fas fa-file-alt"></i></span><?= $this->lang->line('admin_nav_pages'); ?></a></li>
+                  <li><a href="<?= base_url('admin/download'); ?>"><span class="admin-subnav-icon"><i class="fas fa-download"></i></span><?= $this->lang->line('admin_nav_download'); ?></a></li>
                 </ul>
               </li>
               <li class="uk-parent">
@@ -128,6 +129,7 @@
                     <li><a href="<?= base_url('admin/news'); ?>"><span class="admin-subnav-icon"><i class="fas fa-newspaper"></i></span><?= $this->lang->line('admin_nav_news'); ?></a></li>
                     <li><a href="<?= base_url('admin/changelogs'); ?>"><span class="admin-subnav-icon"><i class="fas fa-scroll"></i></span><?= $this->lang->line('admin_nav_changelogs'); ?></a></li>
                     <li><a href="<?= base_url('admin/pages'); ?>"><span class="admin-subnav-icon"><i class="fas fa-file-alt"></i></span><?= $this->lang->line('admin_nav_pages'); ?></a></li>
+                    <li><a href="<?= base_url('admin/download'); ?>"><span class="admin-subnav-icon"><i class="fas fa-download"></i></span><?= $this->lang->line('admin_nav_download'); ?></a></li>
                   </ul>
                 </div>
               </li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the Downloads Module.
This will now be part of the Master repository and not an external Module.

## How Has This Been Tested?
The CMS must be installed correctly, it will install all the databases through the migration, including the new "download" database.

From the Administration panel, a download must be inserted in order to be displayed in the Module.

The images used are from: assets/images/forums/wow-icons. If you need to add one, you must place it right there and with the same measurements, that is: 50x50 pixels.

Download creation and editing should work fine regardless of their category.

Access to the module will be together with the others in the User table, next to "Bugtracker, Vote, Donate, etc"

## Types of changes
- [ ] Change the migration from 38 to 39.
- [ ] New elements in the language files, only for English and Spanish.
- [ ] New "download" database

## Screenshots
![d-1](https://user-images.githubusercontent.com/40796673/117510233-b2b3a580-af59-11eb-9c45-61124f8248ce.png)
![d-2](https://user-images.githubusercontent.com/40796673/117510237-b5ae9600-af59-11eb-8c8e-698ce9171040.png)
![b-3](https://user-images.githubusercontent.com/40796673/117510242-b8a98680-af59-11eb-99c1-9ad022a90e96.png)
