### PR TITLE
ItemSet Tooltip

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -69,7 +69,7 @@ $config['migration_auto_latest'] = FALSE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 39;
+$config['migration_version'] = 40;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/language/english/admin_lang.php
+++ b/application/language/english/admin_lang.php
@@ -231,6 +231,7 @@ $lang['option_internal_url'] = 'Internal URL';
 $lang['option_external_url'] = 'External URL';
 $lang['option_on'] = 'On';
 $lang['option_off'] = 'Off';
+$lang['option_item_set'] = 'Item set';
 
 /*Count Lang*/
 $lang['count_accounts_created'] = 'Accounts created';

--- a/application/language/spanish/admin_lang.php
+++ b/application/language/spanish/admin_lang.php
@@ -231,6 +231,7 @@ $lang['option_internal_url'] = 'URL Interna';
 $lang['option_external_url'] = 'URL Externa';
 $lang['option_on'] = 'On';
 $lang['option_off'] = 'Off';
+$lang['option_item_set'] = 'Conjunto de Item';
 
 /*Count Lang*/
 $lang['count_accounts_created'] = 'Cuentas Creadas';

--- a/application/migrations/024_create_store_items.php
+++ b/application/migrations/024_create_store_items.php
@@ -56,12 +56,6 @@ class Migration_create_store_items extends CI_Migration {
               'qquery' => array(
                       'type' => 'TEXT',
                       'null' => TRUE
-              ),
-			  'item_set' => array(
-					  'constraint' => '10',
-                      'type' => 'INT',
-					  'default' => '0',
-                      'null' => TRUE
               )
 
       ));

--- a/application/migrations/024_create_store_items.php
+++ b/application/migrations/024_create_store_items.php
@@ -56,6 +56,12 @@ class Migration_create_store_items extends CI_Migration {
               'qquery' => array(
                       'type' => 'TEXT',
                       'null' => TRUE
+              ),
+			  'item_set' => array(
+					  'constraint' => '10',
+                      'type' => 'INT',
+					  'default' => '0',
+                      'null' => TRUE
               )
 
       ));

--- a/application/migrations/040_alter_store_items.php
+++ b/application/migrations/040_alter_store_items.php
@@ -1,0 +1,23 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_alter_store_items extends CI_Migration {
+
+    public function up()
+    {
+      $this->dbforge->add_column('store_items', array(
+              'item_set' => array(
+                      'type' => 'INT',
+                      'constraint' => '10',
+                      'default' => '0',
+                      'null' => TRUE
+              ),
+      ));
+    }
+
+    public function down()
+    {
+      $this->dbforge->drop_column('store_items', 'item_set');
+    }
+}

--- a/application/modules/admin/controllers/Admin.php
+++ b/application/modules/admin/controllers/Admin.php
@@ -1061,7 +1061,7 @@ class Admin extends MX_Controller {
         $dp_price = $this->input->post('dp_price');
         $vp_price = $this->input->post('vp_price');
         $command = $this->input->post('command');
-		$iset = $this->input->post('iset');
+        $iset = $this->input->post('iset');
         echo $this->admin_model->insertItem($name, $description, $category, $type, $price_type, $dp_price, $vp_price, $icon, $command, $iset);
     }
 
@@ -1077,7 +1077,7 @@ class Admin extends MX_Controller {
         $dp_price = $this->input->post('dp_price');
         $vp_price = $this->input->post('vp_price');
         $command = $this->input->post('command');
-		$iset = $this->input->post('iset');
+        $iset = $this->input->post('iset');
         echo $this->admin_model->updateSpecifyItem($id, $name, $description, $category, $type, $price_type, $dp_price, $vp_price, $icon, $command, $iset);
     }
 

--- a/application/modules/admin/controllers/Admin.php
+++ b/application/modules/admin/controllers/Admin.php
@@ -1061,7 +1061,8 @@ class Admin extends MX_Controller {
         $dp_price = $this->input->post('dp_price');
         $vp_price = $this->input->post('vp_price');
         $command = $this->input->post('command');
-        echo $this->admin_model->insertItem($name, $description, $category, $type, $price_type, $dp_price, $vp_price, $icon, $command);
+		$iset = $this->input->post('iset');
+        echo $this->admin_model->insertItem($name, $description, $category, $type, $price_type, $dp_price, $vp_price, $icon, $command, $iset);
     }
 
     public function updatestoreitem()
@@ -1076,7 +1077,8 @@ class Admin extends MX_Controller {
         $dp_price = $this->input->post('dp_price');
         $vp_price = $this->input->post('vp_price');
         $command = $this->input->post('command');
-        echo $this->admin_model->updateSpecifyItem($id, $name, $description, $category, $type, $price_type, $dp_price, $vp_price, $icon, $command);
+		$iset = $this->input->post('iset');
+        echo $this->admin_model->updateSpecifyItem($id, $name, $description, $category, $type, $price_type, $dp_price, $vp_price, $icon, $command, $iset);
     }
 
     public function deletestoreitem()

--- a/application/modules/admin/models/Admin_model.php
+++ b/application/modules/admin/models/Admin_model.php
@@ -944,7 +944,7 @@ class Admin_model extends CI_Model {
             'vp' => $setvp,
             'icon' => $icon,
             'command' => $command,
-			'item_set' => $iset
+            'item_set' => $iset
         );
 
         $this->db->insert('store_items', $data);
@@ -976,7 +976,7 @@ class Admin_model extends CI_Model {
             'vp' => $setvp,
             'icon' => $icon,
             'command' => $command,
-			'item_set' => $iset
+            'item_set' => $iset
         );
 
         $this->db->where('id', $id)->update('store_items', $update);

--- a/application/modules/admin/models/Admin_model.php
+++ b/application/modules/admin/models/Admin_model.php
@@ -919,7 +919,7 @@ class Admin_model extends CI_Model {
         return $this->db->select('realmid')->where('id', $id)->get('store_categories')->row('realmid');
     }
 
-    public function insertItem($name, $description, $category, $type, $price_type, $pricedp, $pricevp, $icon, $command)
+    public function insertItem($name, $description, $category, $type, $price_type, $pricedp, $pricevp, $icon, $command, $iset)
     {
         if ($price_type == 1) {
             $setdp = $pricedp;
@@ -943,14 +943,15 @@ class Admin_model extends CI_Model {
             'dp' => $setdp,
             'vp' => $setvp,
             'icon' => $icon,
-            'command' => $command
+            'command' => $command,
+			'item_set' => $iset
         );
 
         $this->db->insert('store_items', $data);
         return true;
     }
 
-    public function updateSpecifyItem($id, $name, $description, $category, $type, $price_type, $pricedp, $pricevp, $icon, $command)
+    public function updateSpecifyItem($id, $name, $description, $category, $type, $price_type, $pricedp, $pricevp, $icon, $command, $iset)
     {
         if ($price_type == 1) {
             $setdp = $pricedp;
@@ -974,7 +975,8 @@ class Admin_model extends CI_Model {
             'dp' => $setdp,
             'vp' => $setvp,
             'icon' => $icon,
-            'command' => $command
+            'command' => $command,
+			'item_set' => $iset
         );
 
         $this->db->where('id', $id)->update('store_items', $update);
@@ -1052,6 +1054,11 @@ class Admin_model extends CI_Model {
     public function getItemSpecifyCommand($id)
     {
         return $this->db->select('command')->where('id', $id)->get('store_items')->row('command');
+    }
+	
+	public function getItemSpecifyItemSet($id)
+    {
+        return $this->db->select('item_set')->where('id', $id)->get('store_items')->row('item_set');
     }
 
     public function insertStoreTop($item)

--- a/application/modules/admin/views/store/create_item.php
+++ b/application/modules/admin/views/store/create_item.php
@@ -51,7 +51,7 @@
                         <option value="5"><?= $this->lang->line('option_customize'); ?></option>
                         <option value="6"><?= $this->lang->line('option_change_faction'); ?></option>
                         <option value="7"><?= $this->lang->line('option_change_race'); ?></option>
-						<option value="8"><?= $this->lang->line('option_item_set'); ?></option>
+                        <option value="8"><?= $this->lang->line('option_item_set'); ?></option>
                       </select>
                     </div>
                   </div>
@@ -95,23 +95,23 @@
                 </div>
               </div>
               <div class="uk-margin-small">
-			     <div class="uk-grid-small" uk-grid>
-			       <div class="uk-inline uk-width-2-3@s">
-				      <label class="uk-form-label"><?= $this->lang->line('placeholder_command'); ?></label>
-					  <div class="uk-form-controls">
-					    <div class="uk-inline uk-width-1-1">
-                          <input class="uk-input" type="text" id="item_command" required>
-                        </div>
-                      </div>
-				    </div>
-                    <div class="uk-inline uk-width-1-3@s">
-                      <label class="uk-form-label"><?=$this->lang->line('option_item_set');?></label>
-                      <div class="uk-form-controls">
-                        <input class="uk-input" type="text" id="item_set" placeholder="0">
+                <div class="uk-grid-small" uk-grid>
+                  <div class="uk-inline uk-width-2-3@s">
+                    <label class="uk-form-label"><?= $this->lang->line('placeholder_command'); ?></label>
+                    <div class="uk-form-controls">
+                      <div class="uk-inline uk-width-1-1">
+                        <input class="uk-input" type="text" id="item_command" required>
                       </div>
                     </div>
+                  </div>
+                  <div class="uk-inline uk-width-1-3@s">
+                    <label class="uk-form-label"><?=$this->lang->line('option_item_set');?></label>
+                    <div class="uk-form-controls">
+                      <input class="uk-input" type="text" id="item_set" placeholder="0">
+                    </div>
+                  </div>
                 </div>
-			  </div>
+              </div>
               <div class="uk-margin-small">
                 <button class="uk-button uk-button-primary uk-width-1-1" type="submit" id="button_item"><i class="fas fa-check-circle"></i> <?= $this->lang->line('button_create'); ?></button>
               </div>
@@ -134,7 +134,7 @@
         var dp_price = $.trim($('#item_dp_price').val());
         var vp_price = $.trim($('#item_vp_price').val());
         var command = $.trim($('#item_command').val());
-		var iset = $.trim($('#item_set').val());
+        var iset = $.trim($('#item_set').val());
         if(name == ''){
           $.amaran({
             'theme': 'awesome error',

--- a/application/modules/admin/views/store/create_item.php
+++ b/application/modules/admin/views/store/create_item.php
@@ -51,6 +51,7 @@
                         <option value="5"><?= $this->lang->line('option_customize'); ?></option>
                         <option value="6"><?= $this->lang->line('option_change_faction'); ?></option>
                         <option value="7"><?= $this->lang->line('option_change_race'); ?></option>
+						<option value="8"><?= $this->lang->line('option_item_set'); ?></option>
                       </select>
                     </div>
                   </div>
@@ -94,13 +95,23 @@
                 </div>
               </div>
               <div class="uk-margin-small">
-                <label class="uk-form-label"><?= $this->lang->line('placeholder_command'); ?></label>
-                <div class="uk-form-controls">
-                  <div class="uk-inline uk-width-1-1">
-                    <input class="uk-input" type="text" id="item_command" required>
-                  </div>
+			     <div class="uk-grid-small" uk-grid>
+			       <div class="uk-inline uk-width-2-3@s">
+				      <label class="uk-form-label"><?= $this->lang->line('placeholder_command'); ?></label>
+					  <div class="uk-form-controls">
+					    <div class="uk-inline uk-width-1-1">
+                          <input class="uk-input" type="text" id="item_command" required>
+                        </div>
+                      </div>
+				    </div>
+                    <div class="uk-inline uk-width-1-3@s">
+                      <label class="uk-form-label"><?=$this->lang->line('option_item_set');?></label>
+                      <div class="uk-form-controls">
+                        <input class="uk-input" type="text" id="item_set" placeholder="0">
+                      </div>
+                    </div>
                 </div>
-              </div>
+			  </div>
               <div class="uk-margin-small">
                 <button class="uk-button uk-button-primary uk-width-1-1" type="submit" id="button_item"><i class="fas fa-check-circle"></i> <?= $this->lang->line('button_create'); ?></button>
               </div>
@@ -123,6 +134,7 @@
         var dp_price = $.trim($('#item_dp_price').val());
         var vp_price = $.trim($('#item_vp_price').val());
         var command = $.trim($('#item_command').val());
+		var iset = $.trim($('#item_set').val());
         if(name == ''){
           $.amaran({
             'theme': 'awesome error',
@@ -174,7 +186,7 @@
         $.ajax({
           url:"<?= base_url($lang.'/admin/store/item/add'); ?>",
           method:"POST",
-          data:{name, description, category, type, price_type, dp_price, vp_price, icon, command},
+          data:{name, description, category, type, price_type, dp_price, vp_price, icon, command, iset},
           dataType:"text",
           beforeSend: function(){
             $.amaran({

--- a/application/modules/admin/views/store/edit_item.php
+++ b/application/modules/admin/views/store/edit_item.php
@@ -51,7 +51,7 @@
                         <option value="5" <?php if($this->admin_model->getItemSpecifyType($idlink) == 5) echo 'selected'; ?>><?= $this->lang->line('option_customize'); ?></option>
                         <option value="6" <?php if($this->admin_model->getItemSpecifyType($idlink) == 6) echo 'selected'; ?>><?= $this->lang->line('option_change_faction'); ?></option>
                         <option value="7" <?php if($this->admin_model->getItemSpecifyType($idlink) == 7) echo 'selected'; ?>><?= $this->lang->line('option_change_race'); ?></option>
-						<option value="8" <?php if($this->admin_model->getItemSpecifyType($idlink) == 8) echo 'selected'; ?>><?= $this->lang->line('option_item_set'); ?></option>
+                        <option value="8" <?php if($this->admin_model->getItemSpecifyType($idlink) == 8) echo 'selected'; ?>><?= $this->lang->line('option_item_set'); ?></option>
                       </select>
                     </div>
                   </div>
@@ -94,24 +94,24 @@
                   </div>
                 </div>
               </div>
-			  <div class="uk-margin-small">
-			     <div class="uk-grid-small" uk-grid>
-			       <div class="uk-inline uk-width-2-3@s">
-				      <label class="uk-form-label"><?= $this->lang->line('placeholder_command'); ?></label>
-					  <div class="uk-form-controls">
-					    <div class="uk-inline uk-width-1-1">
-                          <input class="uk-input" type="text" id="item_command" value="<?= $this->admin_model->getItemSpecifyCommand($idlink); ?>" required>
-                        </div>
-                      </div>
-				    </div>
-                    <div class="uk-inline uk-width-1-3@s">
-                      <label class="uk-form-label"><?=$this->lang->line('option_item_set');?></label>
-                      <div class="uk-form-controls">
-                        <input class="uk-input" type="text" id="item_set" value="<?= $this->admin_model->getItemSpecifyItemSet($idlink); ?>">
+              <div class="uk-margin-small">
+                <div class="uk-grid-small" uk-grid>
+                  <div class="uk-inline uk-width-2-3@s">
+                    <label class="uk-form-label"><?= $this->lang->line('placeholder_command'); ?></label>
+                    <div class="uk-form-controls">
+                      <div class="uk-inline uk-width-1-1">
+                        <input class="uk-input" type="text" id="item_command" value="<?= $this->admin_model->getItemSpecifyCommand($idlink); ?>" required>
                       </div>
                     </div>
+                  </div>
+                  <div class="uk-inline uk-width-1-3@s">
+                    <label class="uk-form-label"><?=$this->lang->line('option_item_set');?></label>
+                    <div class="uk-form-controls">
+                      <input class="uk-input" type="text" id="item_set" value="<?= $this->admin_model->getItemSpecifyItemSet($idlink); ?>">
+                    </div>
+                  </div>
                 </div>
-			  </div>
+              </div>
               <div class="uk-margin-small">
                 <button class="uk-button uk-button-primary uk-width-1-1" id="button_upitem" type="submit"><i class="fas fa-sync-alt"></i> <?= $this->lang->line('button_save'); ?></button>
               </div>
@@ -135,7 +135,7 @@
         var dp_price = $.trim($('#item_dp_price').val());
         var vp_price = $.trim($('#item_vp_price').val());
         var command = $.trim($('#item_command').val());
-		var iset = $.trim($('#item_set').val());
+        var iset = $.trim($('#item_set').val());
         if(name == ''){
           $.amaran({
             'theme': 'awesome error',

--- a/application/modules/admin/views/store/edit_item.php
+++ b/application/modules/admin/views/store/edit_item.php
@@ -51,6 +51,7 @@
                         <option value="5" <?php if($this->admin_model->getItemSpecifyType($idlink) == 5) echo 'selected'; ?>><?= $this->lang->line('option_customize'); ?></option>
                         <option value="6" <?php if($this->admin_model->getItemSpecifyType($idlink) == 6) echo 'selected'; ?>><?= $this->lang->line('option_change_faction'); ?></option>
                         <option value="7" <?php if($this->admin_model->getItemSpecifyType($idlink) == 7) echo 'selected'; ?>><?= $this->lang->line('option_change_race'); ?></option>
+						<option value="8" <?php if($this->admin_model->getItemSpecifyType($idlink) == 8) echo 'selected'; ?>><?= $this->lang->line('option_item_set'); ?></option>
                       </select>
                     </div>
                   </div>
@@ -93,14 +94,24 @@
                   </div>
                 </div>
               </div>
-              <div class="uk-margin-small">
-                <label class="uk-form-label"><?= $this->lang->line('placeholder_command'); ?></label>
-                <div class="uk-form-controls">
-                  <div class="uk-inline uk-width-1-1">
-                    <input class="uk-input" type="text" id="item_command" value="<?= $this->admin_model->getItemSpecifyCommand($idlink); ?>" required>
-                  </div>
+			  <div class="uk-margin-small">
+			     <div class="uk-grid-small" uk-grid>
+			       <div class="uk-inline uk-width-2-3@s">
+				      <label class="uk-form-label"><?= $this->lang->line('placeholder_command'); ?></label>
+					  <div class="uk-form-controls">
+					    <div class="uk-inline uk-width-1-1">
+                          <input class="uk-input" type="text" id="item_command" value="<?= $this->admin_model->getItemSpecifyCommand($idlink); ?>" required>
+                        </div>
+                      </div>
+				    </div>
+                    <div class="uk-inline uk-width-1-3@s">
+                      <label class="uk-form-label"><?=$this->lang->line('option_item_set');?></label>
+                      <div class="uk-form-controls">
+                        <input class="uk-input" type="text" id="item_set" value="<?= $this->admin_model->getItemSpecifyItemSet($idlink); ?>">
+                      </div>
+                    </div>
                 </div>
-              </div>
+			  </div>
               <div class="uk-margin-small">
                 <button class="uk-button uk-button-primary uk-width-1-1" id="button_upitem" type="submit"><i class="fas fa-sync-alt"></i> <?= $this->lang->line('button_save'); ?></button>
               </div>
@@ -124,6 +135,7 @@
         var dp_price = $.trim($('#item_dp_price').val());
         var vp_price = $.trim($('#item_vp_price').val());
         var command = $.trim($('#item_command').val());
+		var iset = $.trim($('#item_set').val());
         if(name == ''){
           $.amaran({
             'theme': 'awesome error',
@@ -175,7 +187,7 @@
         $.ajax({
           url:"<?= base_url($lang.'/admin/store/item/update'); ?>",
           method:"POST",
-          data:{id, name, description, category, type, price_type, dp_price, vp_price, icon, command},
+          data:{id, name, description, category, type, price_type, dp_price, vp_price, icon, command, iset},
           dataType:"text",
           beforeSend: function(){
             $.amaran({

--- a/application/modules/store/models/Store_model.php
+++ b/application/modules/store/models/Store_model.php
@@ -157,7 +157,7 @@ class Store_model extends CI_Model {
         {
             if($item['price_type'] == 1)
             {
-                if ($item['type'] == 1)
+                if ($item['type'] == 1 || $item['type'] == 8)
                 {
                     $this->wowrealm->commandSoap('.send items '.$charname.' "'.$subject.'" "'.$message.'" '.$item['command'], $info['console_username'], $info['console_password'], $info['console_hostname'], $info['console_port'], $info['emulator']);
                 }
@@ -192,7 +192,7 @@ class Store_model extends CI_Model {
             }
             else if ($item['price_type'] == 2)
             {
-                if ($item['type'] == 1)
+                if ($item['type'] == 1 || $item['type'] == 8)
                 {
                     $this->wowrealm->commandSoap('.send items '.$charname.' "'.$subject.'" "'.$message.'" '.$item['command'], $info['console_username'], $info['console_password'], $info['console_hostname'], $info['console_port'], $info['emulator']);
                 }
@@ -227,7 +227,7 @@ class Store_model extends CI_Model {
             }
             else if ($item['price_type'] == 3)
             {
-                if ($item['type'] == 1)
+                if ($item['type'] == 1 || $item['type'] == 8)
                 {
                     $this->wowrealm->commandSoap('.send items '.$charname.' "'.$subject.'" "'.$message.'" '.$item['command'], $info['console_username'], $info['console_password'], $info['console_hostname'], $info['console_port'], $info['emulator']);
                 }

--- a/application/modules/store/views/category.php
+++ b/application/modules/store/views/category.php
@@ -53,6 +53,11 @@
                         <!-- You can use 'es.wowhead' or any other as 'ru, fr, cn' -->
                         <a href="https://wowhead.com/item=<?= $items->command ?>"><?= $items->name ?></a>
                       </span>
+					   <?php elseif($items->type == 8): ?>
+                      <span class="uk-text-middle">
+                        <!-- You can use 'es.wowhead' or any other as 'ru, fr, cn' -->
+                        <a href="https://es.wowhead.com/item-set=-<?= $items->item_set ?>"><?= $items->name ?></a>
+                      </span>
                       <?php else: ?>
                       <span class="uk-text-middle">
                         <a href="#"><?= $items->name ?></a>
@@ -121,5 +126,5 @@
         });
       }
     </script>
-    <script>const whTooltips = {colorLinks: true, iconizeLinks: true, renameLinks: true};</script>
+    <script>const whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false};</script>
     <script src="https://wow.zamimg.com/widgets/power.js"></script>

--- a/application/modules/store/views/category.php
+++ b/application/modules/store/views/category.php
@@ -53,7 +53,7 @@
                         <!-- You can use 'es.wowhead' or any other as 'ru, fr, cn' -->
                         <a href="https://wowhead.com/item=<?= $items->command ?>"><?= $items->name ?></a>
                       </span>
-					   <?php elseif($items->type == 8): ?>
+                      <?php elseif($items->type == 8): ?>
                       <span class="uk-text-middle">
                         <!-- You can use 'es.wowhead' or any other as 'ru, fr, cn' -->
                         <a href="https://es.wowhead.com/item-set=-<?= $items->item_set ?>"><?= $items->name ?></a>

--- a/application/modules/store/views/index.php
+++ b/application/modules/store/views/index.php
@@ -47,16 +47,9 @@
                       <div class="item-store-icon">
                         <img src="https://wow.zamimg.com/images/wow/icons/large/<?= $this->store_model->getIcon($top->store_item); ?>.jpg" alt="">
                       </div>
-                      <!-- START TOOLTIPS WOWHEAD -->
                       <span class="uk-text-middle">
-                        <?php if($items->type == 1): ?>
-                        <!-- You can use 'es.wowhead' or any other as 'ru, fr, cn' -->
-                        <a href="https://wowhead.com/item=<?= $this->store_model->getCommand($top->store_item); ?>"><?= $this->store_model->getName($top->store_item); ?></a>
-                        <?php else: ?>
                         <a href="#"><?= $this->store_model->getName($top->store_item); ?></a>
-                        <?php endif; ?>
                       </span>
-                      <!-- END TOOLTIPS WOWHEAD -->
                     </div>
                     <div id="top-<?= $top->id ?>" class="blizzcms-item-body" hidden>
                       <p class="uk-text-break"><?= $this->store_model->getDescription($top->store_item); ?></p>
@@ -119,5 +112,5 @@
         });
       }
     </script>
-<script>const whTooltips = {colorLinks: true, iconizeLinks: true, renameLinks: true};</script>
+<script>const whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>


### PR DESCRIPTION
## Descripción
Este cambio permitirá ingresar ItemSet en la tienda y tener un modo de combinarlo con los Tooltips que tanto nos gustan.

## ¿Cómo debe ser Testeado?

- Instalar el CMS.
- Crear un Reino.
- Crear una categoría en la tienda.
- Crear un Item con el tipo "Item set".
- Añadir los ID de los items que conforman el set.
- Añadir el ID del ItemSet que quieres visualizar (Este lo puedes sacar de wowhead). Ej: 245 (Paladín Represión T10).
- Se debe de editar correctamente.
- Debe de mostrar el Tooltip del set tal y como muestra en la foto.
- Este cambio no debería de afectar a los demás tooltip en caso de no ser ItemSet.

## Screenshots:
![p12](https://user-images.githubusercontent.com/40796673/118613684-fc3b9600-b78c-11eb-9b83-165092b9bd08.png)


## Tipos de Cambios

- Nuevo campo en la creación y edición de item, (Item Set).
- Nueva columna en **store_item**, (item_set)
- Nueva función para seleccionar la columna **item_set**.
- Adjuntada función para el comando de consola en el Admin_model.


## Checklist:
- [ ] Intalado sin errores.
- [ ] Columna **item_set** creada en la tabla **store_item**.
- [ ] Creación y ediccion de item exitosa.
- [ ] Visualización del tooltip exitosa.