### PR TITLE
Removing character restriction in discord invitation.

### DIFF
--- a/application/modules/home/config/home.php
+++ b/application/modules/home/config/home.php
@@ -12,15 +12,6 @@ $config['discord_type'] = '1';
 
 /**
  *
- * Discord invitation character length
- *
- * Default: 7
- * The new invitations have 10 characters so you should change from 7 to 10 for example.
-*/
-$config['discord_invitation_length'] = 7;
-
-/**
- *
  * The api de discord offers 5 types of styles.
  *
  * Options: shield | banner1 | banner2 | banner3 | banner4

--- a/application/modules/home/models/Home_model.php
+++ b/application/modules/home/models/Home_model.php
@@ -23,7 +23,7 @@ class Home_model extends CI_Model {
         $invitation = $this->config->item('discord_invitation');
         error_reporting(0);
 
-        if ($this->wowmodule->getDiscordStatus() && strlen($invitation) == $this->config->item('discord_invitation_length'))
+        if ($this->wowmodule->getDiscordStatus())
         {
             $discordapi = $this->cache->file->get('discordapi');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Currently, in the config/home.php and in the models, it checks the amount of characters, that the discord invitation has.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The idea is to remove this condition, since many people, at the time of installing the cms, have doubts and ask in the discord how to solve it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Basically, if you entered the characters of the invitation correctly (remember that it is not the URL, but only the characters), the banner should appear correctly.

## Screenshots (if appropriate):

![banner_discord_2](https://user-images.githubusercontent.com/2810187/137170246-536dc432-8c1a-42e6-ae3f-09d1ab170e87.png)

![banner_discord](https://user-images.githubusercontent.com/2810187/137169081-2f932d2d-a5fc-4793-8f29-6bc77d9ae1ba.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.