### PR TITLE
fix(Core/Article) The getTopicLocked() method no longer exists.

### DIFF
--- a/application/modules/news/views/article.php
+++ b/application/modules/news/views/article.php
@@ -55,7 +55,7 @@
                 </div>
               </div>
               <?php endforeach; ?>
-              <?php if(!$this->wowauth->isLogged() && $this->forum_model->getTopicLocked($idlink) == 0): ?>
+              <?php if(!$this->wowauth->isLogged()): ?>
               <div>
                 <div class="uk-card uk-card-default uk-card-body">
                   <h3 class="uk-h3 uk-text-center"><span uk-icon="icon: comment; ratio: 1.5"></span> <?= $this->lang->line('forum_comment_header'); ?></h3>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When trying to access an article, an error is generated, which does not finish displaying it. Reviewing the form model, I did not find the method that was used inside the conditional, so I eliminated it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The error was reported by a person in the cms discord.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Trying to enter an article, without being logged in.
- The error only takes place when the person does not have an active session.

## Screenshots (if appropriate):

![article_bug](https://user-images.githubusercontent.com/2810187/138504112-1417f03a-218c-49aa-a1c9-69e10d5eb294.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.