### PR TITLE
Removing getCountPostAuthor() from the view

### DIFF
--- a/application/modules/forum/views/topic.php
+++ b/application/modules/forum/views/topic.php
@@ -61,7 +61,7 @@
                     </div>
                   </div>
                   <p class="uk-text-bold uk-text-center uk-margin-remove"><?= $this->wowauth->getUsernameID($commentss->author); ?></p>
-                  <p class="uk-margin-remove uk-text-meta uk-text-center"><?= $this->forum_model->getCountPostAuthor($commentss->author); ?> <?= $this->lang->line('forum_post_count'); ?></p>
+                  <p class="uk-margin-remove uk-text-meta uk-text-center"><?= $this->lang->line('forum_post_count'); ?></p>
                   <?php if($this->wowauth->getRank($commentss->author) > 0): ?>
                 <div class="author-rank-staff"><i class="fas fa-fire"></i> Staff</div>
                   <?php endif; ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
After correcting the problem of creating the response in the last pull request, it is redirected to the subject in question, and an error occurs, because in the view, it makes use of a method that does not exist.

An uncaught Exception was encountered
Type: Error
Message: Call to undefined method Forum_model::getCountPostAuthor()
Filename: D:\xampp\htdocs\blizzcms\application\modules\forum\views\topic.php
Line Number: 64

![forum_error](https://user-images.githubusercontent.com/2810187/140443375-af7e14bd-cff7-4a44-8970-acf124ca446a.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Correct this problem within the forum.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Create a topic in the forum, and then try to add a reply, currently, you could not, due to a 500 error, but a contributor fixed that problem. However, when doing the redirection, the call was made to a method that does not exist in the model, which caused an error.

## Screenshots (if appropriate):

![ejemplo](https://user-images.githubusercontent.com/2810187/140443384-b53460a5-02fa-4e09-89c0-e6dd550889ff.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.