### PR TITLE
Allow the use of the - character in the URI

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -159,7 +159,7 @@ $config['composer_autoload'] = FCPATH.'vendor/autoload.php';
 | DO NOT CHANGE THIS UNLESS YOU FULLY UNDERSTAND THE REPERCUSSIONS!!
 |
 */
-$config['permitted_uri_chars'] = '‘a-z 0-9~%.:\_\=+%\&';
+$config['permitted_uri_chars'] = '‘a-z 0-9~%.:\_\=+%\&-';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, it is not allowed to use the `-` character in the url. Therefore, it is not possible to create routes with this character.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Generally, friendly urls usually use this character to generate the paths.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Try to create a path with this character, for example in the page section of the administrator.

## Screenshots (if appropriate):
![uri](https://user-images.githubusercontent.com/2810187/156371770-f2e4c139-02c5-4cba-8c64-8277e93d4772.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)