### PR TITLE
Fixed a problem when watching an inexistant report

### DIFF
--- a/application/modules/bugtracker/controllers/Bugtracker.php
+++ b/application/modules/bugtracker/controllers/Bugtracker.php
@@ -111,6 +111,9 @@ class Bugtracker extends MX_Controller {
         if (!$this->wowmodule->getBugtrackerStatus())
             redirect(base_url(),'refresh');
 
+		if ($this->bugtracker_model->ReportExist($id) == 0)
+			redirect(base_url('404'), 'refresh');
+		
         $data = array(
             'idlink' => $id,
             'pagetitle' => $this->lang->line('tab_bugtracker'),

--- a/application/modules/bugtracker/models/Bugtracker_model.php
+++ b/application/modules/bugtracker/models/Bugtracker_model.php
@@ -173,4 +173,9 @@ class Bugtracker_model extends CI_Model {
     {
         return $this->db->select('author')->where('id', $id)->get('bugtracker')->row('author');
     }
+	
+	public function ReportExist($id)
+	{
+		return $this->db->select('*')->where('id', $id)->get('bugtracker')->num_rows();
+	}
 }


### PR DESCRIPTION
When you watch an inexistant report in your bugtracker, you will have a strange page with nothing in

## Description
Added a condition if the report exist in database.
If not -> 404

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.