### PR TITLE
Update RealmStatus function

### DIFF
--- a/application/models/Realm_model.php
+++ b/application/models/Realm_model.php
@@ -30,9 +30,19 @@ class Realm_model extends CI_Model {
         return $this->auth->select('port')->where('id', $id)->get('realmlist')->row('port');
     }
 
+    public function getRealmPortByRealmID($realmID)
+    {
+        return $this->db->select('console_port')->where('realmID', $realmID)->get('realms')->row('console_port');
+    }
+
+    public function getRealmHostnameByRealmID($realmID)
+    {
+        return $this->db->select('hostname')->where('realmID', $realmID)->get('realms')->row('hostname');
+    }
+
     public function RealmStatus($MultiRealm, $host, $status = false)
     {
-        $port = $this->getRealmPort($MultiRealm);
+        $port = $this->getRealmPortByRealmID($MultiRealm);
         error_reporting(0);
 
         if ($this->RealmStatus != null)

--- a/application/modules/home/views/home.php
+++ b/application/modules/home/views/home.php
@@ -75,14 +75,14 @@
                       <h5 class="uk-h5 uk-text-bold uk-margin-small"><a href="<?= base_url('online'); ?>" class="uk-link-reset"><i class="fas fa-server"></i> <?= $this->lang->line('table_header_realm'); ?> <?= $this->wowrealm->getRealmName($charsMultiRealm->realmID); ?></a></h5>
                     </div>
                     <div class="uk-width-auto">
-                      <?php if ($this->wowrealm->RealmStatus($charsMultiRealm->realmID, $this->wowrealm->realmGetHostname($charsMultiRealm->realmID))): ?>
+                      <?php if ($this->wowrealm->RealmStatus($charsMultiRealm->realmID, $this->wowrealm->getRealmHostnameByRealmID($charsMultiRealm->realmID))): ?>
                         <div class="status-dot online" uk-tooltip="<?= $this->lang->line('online'); ?>"><span><span></span></span></div>
                       <?php else: ?>
                         <div class="status-dot offline" uk-tooltip="<?= $this->lang->line('offline'); ?>"><span><span></span></span></div>
                       <?php endif ?>
                     </div>
                   </div>
-                  <?php if ($this->wowrealm->RealmStatus($charsMultiRealm->realmID, $this->wowrealm->realmGetHostname($charsMultiRealm->realmID))): ?>
+                  <?php if ($this->wowrealm->RealmStatus($charsMultiRealm->realmID, $this->wowrealm->getRealmHostnameByRealmID($charsMultiRealm->realmID))): ?>
                   <div class="uk-grid uk-grid-collapse uk-margin-small" data-uk-grid>
                     <div class="uk-width-1-2">
                       <div class="uk-tile alliance-bar uk-text-center" uk-tooltip="<?= $this->lang->line('faction_alliance'); ?>">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, the function that is responsible for verifying whether the realm is online or not depends on the auth database. When in fact, this verification should be done based on the data that the user enters in the form when registering the realm.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Within the community discord, 2 people stated that they could not get the server to come online. After several conversations, it was determined that the best way to check is to read the information that the person fills in the form.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The only way to check this is to create a realm where the IP is public and then where the private IP is used. Both ways, it should work, as long as, in case of using the public IP, the port is open and listening to that IP address.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.